### PR TITLE
Fix critical Firestore rules and Hosting deploy path

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,40 +1,35 @@
 {
-    "database": {
-        "rules": "database.rules.json"
-    },
-    "hosting": [{
-            "target": "firebase-example-app",
-            "public": "dist/firebase-example-app",
-            "ignore": [
-                "firebase.json",
-                ".firebaserc",
-                ".git",
-                ".gitignore",
-                ".editorconfig",
-                "src/**/.*",
-                "database.rules.json",
-                "package.json",
-                "README.md",
-                "tsconfig.json",
-                "**/node_modules/**"
-            ],
-            "rewrites": [{
-                "source": "**",
-                "destination": "/index.html"
-            }]
-        },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "hosting": [
+    {
+      "target": "firebase-example-app",
+      "public": "dist/firebase-example-app/browser",
+      "ignore": [
+        "firebase.json",
+        ".firebaserc",
+        ".git",
+        ".gitignore",
+        ".editorconfig",
+        "firestore.rules",
+        "firestore.indexes.json",
+        "database.rules.json",
+        "package.json",
+        "README.md",
+        "tsconfig.json",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
         {
-            "target": "firebase-example-app",
-            "public": "dist/firebase-example-app",
-            "ignore": [
-                "firebase.json",
-                "**/.*",
-                "**/node_modules/**"
-            ],
-            "rewrites": [{
-                "source": "**",
-                "destination": "/index.html"
-            }]
+          "source": "**",
+          "destination": "/index.html"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if isOwner(userId);
+
+      match /meals/{mealId} {
+        allow read, write: if isOwner(userId);
+      }
+
+      match /workouts/{workoutId} {
+        allow read, write: if isOwner(userId);
+      }
+
+      match /schedule/{scheduleId} {
+        allow read, write: if isOwner(userId);
+      }
+    }
+  }
+
+  function isOwner(userId) {
+    return request.auth != null && request.auth.uid == userId;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes both **P0 critical issues** from the post-upgrade audit.

## Changes

### 1. Add Firestore security rules (P0)
- New `firestore.rules` restricts access to authenticated owners only
- Rules cover `users/{userId}` and subcollections: `meals`, `workouts`, `schedule`
- Added `firestore.indexes.json` (empty indexes; schedule queries use single-field `timestamp` ordering)
- Registered Firestore config in `firebase.json`

### 2. Fix Firebase Hosting deploy path (P0)
- Updated `public` from `dist/firebase-example-app` → `dist/firebase-example-app/browser`
- Matches Angular 22 application builder output layout
- Removed duplicate hosting target block

## Verification

- `npm run build` — pass
- Confirmed `dist/firebase-example-app/browser/index.html` exists after build

## Deploy note

After merge, deploy rules and hosting together:

```bash
firebase deploy --only firestore:rules,hosting
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f26b4-05ac-7765-9903-828bf6a46f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f26b4-05ac-7765-9903-828bf6a46f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

