### PR TITLE
Add comprehensive unit test coverage and fix related bugs

### DIFF
--- a/src/app/components/app/app-header/app-header.component.spec.ts
+++ b/src/app/components/app/app-header/app-header.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppHeaderComponent } from './app-header.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('AppHeaderComponent', () => {
+  let fixture: ComponentFixture<AppHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [AppHeaderComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AppHeaderComponent);
+    fixture.componentInstance.user = {
+      email: 'test@example.com',
+      uid: '1',
+      authenticated: true
+    };
+    fixture.detectChanges();
+  });
+
+  it('should render the user email', () => {
+    expect(fixture.nativeElement.querySelector('#user-name').textContent).toContain('test@example.com');
+  });
+
+  it('should emit logout when the button is clicked', () => {
+    spyOn(fixture.componentInstance.logout, 'emit');
+    fixture.nativeElement.querySelector('button').click();
+    expect(fixture.componentInstance.logout.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/app/app-nav/app-nav.component.spec.ts
+++ b/src/app/components/app/app-nav/app-nav.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppNavComponent } from './app-nav.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('AppNavComponent', () => {
+  let fixture: ComponentFixture<AppNavComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [AppNavComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AppNavComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should expose workouts navigation with the correct aria label', () => {
+    const workoutsLink = fixture.nativeElement.querySelector('a[routerLink="/workouts"] mat-icon');
+    expect(workoutsLink.getAttribute('aria-label')).toBe('Workouts section');
+  });
+});

--- a/src/app/components/app/app-nav/app-nav.component.ts
+++ b/src/app/components/app/app-nav/app-nav.component.ts
@@ -32,7 +32,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
       class="flex-row-container flex-justify-content-center flex-align-items-center border-radius-5"
       routerLink="/workouts"
       routerLinkActive="active-link">
-      <mat-icon aria-hidden="false" aria-label="Meals section">fitness_center</mat-icon>
+      <mat-icon aria-hidden="false" aria-label="Workouts section">fitness_center</mat-icon>
       <span class="margin-left-10">Workouts</span>
     </a>
 

--- a/src/app/containers/app/app.component.spec.ts
+++ b/src/app/containers/app/app.component.spec.ts
@@ -1,26 +1,40 @@
 import { TestBed } from '@angular/core/testing';
+import { Router, NavigationEnd } from '@angular/router';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Subject, of } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
 import { Store } from 'src/app/store/store';
-import { of } from 'rxjs';
 
 describe('AppComponent', () => {
+  let routerEvents$: Subject<NavigationEnd>;
+  let logoutSpy: jasmine.Spy;
+  let navigateSpy: jasmine.Spy;
+
   beforeEach(async () => {
+    routerEvents$ = new Subject<NavigationEnd>();
+    logoutSpy = jasmine.createSpy('logoutUser').and.returnValue(Promise.resolve());
+    navigateSpy = jasmine.createSpy('navigate');
+
     await TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
         Store,
         {
           provide: AuthService,
           useValue: {
             auth$: of(null),
-            logoutUser: () => Promise.resolve()
+            logoutUser: logoutSpy
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents$.asObservable(),
+            navigate: navigateSpy
           }
         }
       ]
@@ -29,7 +43,25 @@ describe('AppComponent', () => {
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should mark auth routes when navigating to login or register', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    routerEvents$.next(new NavigationEnd(1, '/auth/login', '/auth/login'));
+    expect(fixture.componentInstance.isAuthUrl).toBeTrue();
+
+    routerEvents$.next(new NavigationEnd(2, '/schedule', '/schedule'));
+    expect(fixture.componentInstance.isAuthUrl).toBeFalse();
+  });
+
+  it('should logout and navigate to login', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    await fixture.componentInstance.onLogout();
+
+    expect(logoutSpy).toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith(['/auth/login']);
   });
 });

--- a/src/app/modules/auth/login/containers/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/containers/login/login.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { LoginComponent } from './login.component';
+import { AuthFormComponent } from 'src/app/modules/auth/shared/components/auth-form/auth-form.component';
+import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService', ['loginUser']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, MaterialModule],
+      declarations: [LoginComponent, AuthFormComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should navigate home after a successful login', async () => {
+    authService.loginUser.and.returnValue(Promise.resolve({} as never));
+
+    await component.loginUser({
+      value: { email: 'test@example.com', password: 'secret' }
+    } as never);
+
+    expect(authService.loginUser).toHaveBeenCalledWith('test@example.com', 'secret');
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('should expose login errors', async () => {
+    authService.loginUser.and.returnValue(Promise.reject(new Error('Invalid credentials')));
+
+    await component.loginUser({
+      value: { email: 'test@example.com', password: 'wrong' }
+    } as never);
+
+    expect(component.error).toBe('Invalid credentials');
+  });
+});

--- a/src/app/modules/auth/register/containers/register/register.component.spec.ts
+++ b/src/app/modules/auth/register/containers/register/register.component.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RegisterComponent } from './register.component';
+import { AuthFormComponent } from 'src/app/modules/auth/shared/components/auth-form/auth-form.component';
+import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService', ['createUser']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, MaterialModule],
+      declarations: [RegisterComponent, AuthFormComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(RegisterComponent).componentInstance;
+  });
+
+  it('should navigate home after successful registration', async () => {
+    authService.createUser.and.returnValue(Promise.resolve({} as never));
+
+    await component.registerUser({
+      value: { email: 'test@example.com', password: 'secret' }
+    } as never);
+
+    expect(authService.createUser).toHaveBeenCalledWith('test@example.com', 'secret');
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('should expose registration errors', async () => {
+    authService.createUser.and.returnValue(Promise.reject(new Error('Email already in use')));
+
+    await component.registerUser({
+      value: { email: 'test@example.com', password: 'secret' }
+    } as never);
+
+    expect(component.error).toBe('Email already in use');
+  });
+});

--- a/src/app/modules/auth/shared/components/auth-form/auth-form.component.spec.ts
+++ b/src/app/modules/auth/shared/components/auth-form/auth-form.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { AuthFormComponent } from './auth-form.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('AuthFormComponent', () => {
+  let component: AuthFormComponent;
+  let fixture: ComponentFixture<AuthFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, MaterialModule],
+      declarations: [AuthFormComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should not emit invalid submissions', () => {
+    spyOn(component.submitted, 'emit');
+    component.onSubmit();
+    expect(component.submitted.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit the form when valid', () => {
+    spyOn(component.submitted, 'emit');
+    component.form.setValue({
+      email: 'test@example.com',
+      password: 'secret'
+    });
+
+    component.onSubmit();
+
+    expect(component.submitted.emit).toHaveBeenCalledWith(component.form);
+  });
+});

--- a/src/app/modules/auth/shared/guards/auth.guard.spec.ts
+++ b/src/app/modules/auth/shared/guards/auth.guard.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { Auth } from '@angular/fire/auth';
+import { AuthGuard } from './auth.guard';
+import { installFirebaseTestMocks } from 'src/app/testing/firebase-test-harness';
+import { mockAuth, mockFirebaseUser } from 'src/app/testing/firebase.mock';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let router: Router;
+  let mocks: ReturnType<typeof installFirebaseTestMocks>;
+
+  beforeEach(() => {
+    mocks = installFirebaseTestMocks(mockFirebaseUser);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: Auth, useValue: mockAuth },
+        {
+          provide: Router,
+          useValue: {
+            createUrlTree: jasmine.createSpy('createUrlTree').and.callFake(
+              (commands: string[]) => ({ commands } as unknown as UrlTree)
+            )
+          }
+        }
+      ]
+    });
+
+    guard = TestBed.inject(AuthGuard);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow authenticated users', (done) => {
+    mocks.onAuthStateChanged.and.callFake((_auth, next) => {
+      (next as (value: unknown) => void)(mockFirebaseUser);
+      return () => undefined;
+    });
+
+    guard.canActivate().subscribe(result => {
+      expect(result).toBeTrue();
+      done();
+    });
+  });
+
+  it('should redirect unauthenticated users to login', (done) => {
+    mocks.onAuthStateChanged.and.callFake((_auth, next) => {
+      (next as (value: unknown) => void)(null);
+      return () => undefined;
+    });
+
+    guard.canActivate().subscribe(result => {
+      expect(router.createUrlTree).toHaveBeenCalledWith(['/auth/login']);
+      expect(result).toEqual({ commands: ['/auth/login'] } as unknown as UrlTree);
+      done();
+    });
+  });
+});

--- a/src/app/modules/auth/shared/guards/auth.guard.ts
+++ b/src/app/modules/auth/shared/guards/auth.guard.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Router, CanActivate, UrlTree } from '@angular/router';
 import { Auth } from '@angular/fire/auth';
-import { onAuthStateChanged } from 'firebase/auth';
+import { onAuthStateChanged } from 'src/app/utils/firebase-auth.utils';
 
 // rxjs
 import { Observable } from 'rxjs';

--- a/src/app/modules/auth/shared/services/auth/auth.service.spec.ts
+++ b/src/app/modules/auth/shared/services/auth/auth.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { Auth } from '@angular/fire/auth';
+import { AuthService } from './auth.service';
+import { Store } from 'src/app/store/store';
+import { installFirebaseTestMocks } from 'src/app/testing/firebase-test-harness';
+import { mockAuth, mockFirebaseUser } from 'src/app/testing/firebase.mock';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let store: Store;
+  let mocks: ReturnType<typeof installFirebaseTestMocks>;
+
+  beforeEach(() => {
+    mocks = installFirebaseTestMocks(mockFirebaseUser);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        Store,
+        { provide: Auth, useValue: mockAuth }
+      ]
+    });
+
+    service = TestBed.inject(AuthService);
+    store = TestBed.inject(Store);
+  });
+
+  it('should sync authenticated users into the store', (done) => {
+    service.auth$.subscribe(() => {
+      expect(store.value.user).toEqual({
+        email: mockFirebaseUser.email,
+        uid: mockFirebaseUser.uid,
+        authenticated: true
+      });
+      done();
+    });
+  });
+
+  it('should expose the current firebase user', () => {
+    expect(service.user).toBe(mockFirebaseUser);
+  });
+
+  it('should delegate login to firebase auth', async () => {
+    await service.loginUser('test@example.com', 'secret');
+
+    expect(mocks.signInUser).toHaveBeenCalledWith(
+      mockAuth,
+      'test@example.com',
+      'secret'
+    );
+  });
+
+  it('should delegate registration to firebase auth', async () => {
+    await service.createUser('test@example.com', 'secret');
+
+    expect(mocks.registerUser).toHaveBeenCalledWith(
+      mockAuth,
+      'test@example.com',
+      'secret'
+    );
+  });
+
+  it('should delegate logout to firebase auth', async () => {
+    await service.logoutUser();
+
+    expect(mocks.signOutUser).toHaveBeenCalledWith(mockAuth);
+  });
+});

--- a/src/app/modules/auth/shared/services/auth/auth.service.ts
+++ b/src/app/modules/auth/shared/services/auth/auth.service.ts
@@ -1,8 +1,16 @@
 import { Injectable } from '@angular/core';
-import { Auth, authState, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, User } from '@angular/fire/auth';
+import { Auth, User } from '@angular/fire/auth';
 
 // store
 import { Store } from 'src/app/store/store';
+
+// utils
+import {
+  observeAuthState,
+  registerUser,
+  signInUser,
+  signOutUser
+} from 'src/app/utils/firebase-auth.utils';
 
 // rxjs
 import { Observable } from 'rxjs';
@@ -14,7 +22,7 @@ import { User as AppUser } from 'src/app/models/user.interface';
 @Injectable()
 export class AuthService {
 
-  auth$: Observable<User | null> = authState(this.auth).pipe(
+  auth$: Observable<User | null> = observeAuthState(this.auth).pipe(
     tap((next: User | null) => {
       if (!next) {
         this.store.set('user', null);
@@ -39,19 +47,19 @@ export class AuthService {
   }
 
   get authState(): Observable<User | null> {
-    return authState(this.auth);
+    return observeAuthState(this.auth);
   }
 
   createUser(email: string, password: string) {
-    return createUserWithEmailAndPassword(this.auth, email, password);
+    return registerUser(this.auth, email, password);
   }
 
   loginUser(email: string, password: string) {
-    return signInWithEmailAndPassword(this.auth, email, password);
+    return signInUser(this.auth, email, password);
   }
 
   logoutUser() {
-    return signOut(this.auth);
+    return signOutUser(this.auth);
   }
 
 }

--- a/src/app/modules/nav-options/meals/components/meal-form/meal-form.component.spec.ts
+++ b/src/app/modules/nav-options/meals/components/meal-form/meal-form.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MealFormComponent } from './meal-form.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { Meal } from 'src/app/models/meal.interface';
+
+describe('MealFormComponent', () => {
+  let component: MealFormComponent;
+  let fixture: ComponentFixture<MealFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, RouterTestingModule, MaterialModule],
+      declarations: [MealFormComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MealFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should emit create events for valid new meals', () => {
+    spyOn(component.create, 'emit');
+    component.form.setValue({ name: 'Toast', ingredients: ['bread'] });
+
+    component.createMeal();
+
+    expect(component.create.emit).toHaveBeenCalledWith(jasmine.objectContaining({
+      name: 'Toast',
+      ingredients: ['bread']
+    }));
+  });
+
+  it('should populate the form when editing an existing meal', () => {
+    const meal: Meal = {
+      name: 'Omelette',
+      ingredients: ['eggs', 'cheese'],
+      timestamp: 1,
+      $key: 'meal-1',
+      $exists: () => true
+    };
+
+    component.meal = meal;
+    component.ngOnChanges({
+      meal: {
+        currentValue: meal,
+        previousValue: undefined,
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    });
+
+    expect(component.exists).toBeTrue();
+    expect(component.form.get('name')?.value).toBe('Omelette');
+    expect(component.ingredients.length).toBe(2);
+  });
+});

--- a/src/app/modules/nav-options/meals/containers/meal/meal.component.spec.ts
+++ b/src/app/modules/nav-options/meals/containers/meal/meal.component.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of, EMPTY } from 'rxjs';
+import { MealComponent } from './meal.component';
+import { MealsService } from 'src/app/modules/nav-options/shared/services/meals/meals.service';
+import { MealFormComponent } from '../../components/meal-form/meal-form.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Meal } from 'src/app/models/meal.interface';
+
+describe('MealComponent', () => {
+  let component: MealComponent;
+  let mealsService: jasmine.SpyObj<MealsService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    mealsService = jasmine.createSpyObj('MealsService', ['addMeal', 'updateMeal', 'deleteMeal', 'getMeal'], {
+      meals$: of([])
+    });
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, MaterialModule],
+      declarations: [MealComponent, MealFormComponent],
+      providers: [
+        { provide: MealsService, useValue: mealsService },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ id: 'meal-1' }),
+            snapshot: { params: { id: 'meal-1' } }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(MealComponent).componentInstance;
+  });
+
+  it('should redirect to meals when an unknown id is requested', fakeAsync(() => {
+    mealsService.getMeal.and.returnValue(of(undefined));
+
+    component.ngOnInit();
+    component.meal$.subscribe();
+    tick();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/meals']);
+  }));
+
+  it('should create meals and navigate back to the list', async () => {
+    mealsService.getMeal.and.returnValue(EMPTY);
+    mealsService.addMeal.and.returnValue(Promise.resolve({ id: 'new-meal' } as never));
+    component.ngOnInit();
+
+    const meal: Meal = {
+      name: 'Toast',
+      ingredients: ['bread'],
+      timestamp: 1,
+      $key: '',
+      $exists: () => false
+    };
+
+    await component.addMeal(meal);
+
+    expect(mealsService.addMeal).toHaveBeenCalledWith(meal);
+    expect(router.navigate).toHaveBeenCalledWith(['/meals']);
+  });
+});

--- a/src/app/modules/nav-options/meals/containers/meals/meals.component.spec.ts
+++ b/src/app/modules/nav-options/meals/containers/meals/meals.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MealsComponent } from './meals.component';
+import { MealsService } from 'src/app/modules/nav-options/shared/services/meals/meals.service';
+import { Store } from 'src/app/store/store';
+import { ListItemComponent } from 'src/app/modules/nav-options/shared/components/list-item/list-item.component';
+import { JoinPipe } from 'src/app/modules/nav-options/shared/pipes/join.pipe';
+import { WorkoutPipe } from 'src/app/modules/nav-options/shared/pipes/workout.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Meal } from 'src/app/models/meal.interface';
+
+describe('MealsComponent', () => {
+  let component: MealsComponent;
+  let mealsService: jasmine.SpyObj<MealsService>;
+
+  beforeEach(async () => {
+    mealsService = jasmine.createSpyObj('MealsService', ['deleteMeal'], {
+      meals$: of([])
+    });
+    mealsService.deleteMeal.and.returnValue(Promise.resolve());
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [MealsComponent, ListItemComponent, JoinPipe, WorkoutPipe],
+      providers: [
+        Store,
+        { provide: MealsService, useValue: mealsService }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(MealsComponent).componentInstance;
+    component.ngOnInit();
+  });
+
+  it('should delete meals and handle failures', async () => {
+    const meal: Meal = {
+      name: 'Toast',
+      ingredients: ['bread'],
+      timestamp: 1,
+      $key: 'meal-1',
+      $exists: () => true
+    };
+
+    await component.removeMeal(meal);
+
+    expect(mealsService.deleteMeal).toHaveBeenCalledWith('meal-1');
+  });
+});

--- a/src/app/modules/nav-options/meals/containers/meals/meals.component.ts
+++ b/src/app/modules/nav-options/meals/containers/meals/meals.component.ts
@@ -45,7 +45,7 @@ import { Meal } from 'src/app/models/meal.interface';
       <div
         *ngIf="!meals.length"
         class="flex-row-container flex-justify-content-space-between flex-align-items-center padding-10 background-color-gray-1">
-        <mat-icon color="warn" aria-hidden="false" aria-label="Logout">error_outline</mat-icon>
+        <mat-icon color="warn" aria-hidden="false" aria-label="No meals">error_outline</mat-icon>
         <span>No meals, add a new meal to start</span>
       </div>
       <list-item
@@ -86,8 +86,12 @@ export class MealsComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  removeMeal(event: Meal): void {
-    this.mealsService.deleteMeal(event.$key);
+  async removeMeal(event: Meal): Promise<void> {
+    try {
+      await this.mealsService.deleteMeal(event.$key);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
 }

--- a/src/app/modules/nav-options/schedule/components/schedule-assign/schedule-assign.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-assign/schedule-assign.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScheduleAssignComponent } from './schedule-assign.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('ScheduleAssignComponent', () => {
+  let component: ScheduleAssignComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [ScheduleAssignComponent]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleAssignComponent).componentInstance;
+    component.section = { type: 'meals', assigned: ['Soup'] };
+    component.list = [{
+      name: 'Soup',
+      ingredients: ['water'],
+      timestamp: 1,
+      $key: '1',
+      $exists: () => true
+    }];
+    component.ngOnInit();
+  });
+
+  it('should toggle selected assignment items', () => {
+    expect(component.exists('Soup')).toBeTrue();
+
+    component.toggleItem('Soup');
+    expect(component.exists('Soup')).toBeFalse();
+
+    component.toggleItem('Salad');
+    expect(component.exists('Salad')).toBeTrue();
+  });
+
+  it('should emit updated assignments', () => {
+    spyOn(component.updatingItems, 'emit');
+
+    component.updateAssign();
+
+    expect(component.updatingItems.emit).toHaveBeenCalledWith({ meals: ['Soup'] });
+  });
+
+  it('should build create routes from section type', () => {
+    expect(component.getRoute('meals')).toEqual(['../meals/new']);
+    expect(component.getRoute('workouts')).toEqual(['../workouts/new']);
+  });
+});

--- a/src/app/modules/nav-options/schedule/components/schedule-calendar/schedule-calendar.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-calendar/schedule-calendar.component.spec.ts
@@ -1,0 +1,73 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScheduleCalendarComponent } from './schedule-calendar.component';
+import { ScheduleControlsComponent } from '../schedule-controls/schedule-controls.component';
+import { ScheduleDaysComponent } from '../schedule-days/schedule-days.component';
+import { ScheduleSectionComponent } from '../schedule-section/schedule-section.component';
+import { JoinPipe } from 'src/app/modules/nav-options/shared/pipes/join.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { ScheduleList } from 'src/app/models/schedule-list.interface';
+
+describe('ScheduleCalendarComponent', () => {
+  let component: ScheduleCalendarComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [
+        ScheduleCalendarComponent,
+        ScheduleControlsComponent,
+        ScheduleDaysComponent,
+        ScheduleSectionComponent,
+        JoinPipe
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleCalendarComponent).componentInstance;
+    component.items = {
+      morning: {
+        meals: ['Omelette'],
+        workouts: null,
+        section: 'morning',
+        timestamp: 1
+      }
+    } as ScheduleList;
+    component.date = new Date('2026-07-02T12:00:00');
+    component.ngOnChanges({});
+  });
+
+  it('should return schedule sections by key', () => {
+    expect(component.getSection('morning').meals).toEqual(['Omelette']);
+    expect(component.getSection('missing').meals).toBeUndefined();
+  });
+
+  it('should emit selected section events with the current day', () => {
+    spyOn(component.selectedSection, 'emit');
+
+    component.selectSection({
+      type: 'meals',
+      assigned: ['Omelette'],
+      data: component.items.morning
+    }, 'morning');
+
+    expect(component.selectedSection.emit).toHaveBeenCalledWith(jasmine.objectContaining({
+      section: 'morning',
+      day: component.selectedDay
+    }));
+  });
+
+  it('should emit date changes when selecting a day in the week', () => {
+    spyOn(component.changingDate, 'emit');
+
+    component.selectDay(2);
+
+    expect(component.changingDate.emit).toHaveBeenCalled();
+  });
+
+  it('should move the calendar by whole weeks', () => {
+    spyOn(component.changingDate, 'emit');
+
+    component.onMovingDate(1);
+
+    expect(component.changingDate.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/nav-options/schedule/components/schedule-controls/schedule-controls.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-controls/schedule-controls.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScheduleControlsComponent } from './schedule-controls.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('ScheduleControlsComponent', () => {
+  let component: ScheduleControlsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [ScheduleControlsComponent]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleControlsComponent).componentInstance;
+  });
+
+  it('should emit week offsets', () => {
+    spyOn(component.movingDate, 'emit');
+
+    component.moveDate(-1);
+
+    expect(component.offset).toBe(-1);
+    expect(component.movingDate.emit).toHaveBeenCalledWith(-1);
+  });
+});

--- a/src/app/modules/nav-options/schedule/components/schedule-days/schedule-days.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-days/schedule-days.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScheduleDaysComponent } from './schedule-days.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('ScheduleDaysComponent', () => {
+  let component: ScheduleDaysComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [ScheduleDaysComponent]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleDaysComponent).componentInstance;
+  });
+
+  it('should emit the selected day index', () => {
+    spyOn(component.selectingDay, 'emit');
+
+    component.selectDay(3);
+
+    expect(component.selectingDay.emit).toHaveBeenCalledWith(3);
+  });
+});

--- a/src/app/modules/nav-options/schedule/components/schedule-section/schedule-section.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-section/schedule-section.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScheduleSectionComponent } from './schedule-section.component';
+import { JoinPipe } from 'src/app/modules/nav-options/shared/pipes/join.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { ScheduleItem } from 'src/app/models/schedule-item.interface';
+
+describe('ScheduleSectionComponent', () => {
+  let component: ScheduleSectionComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [ScheduleSectionComponent, JoinPipe]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleSectionComponent).componentInstance;
+    component.section = {
+      meals: ['Omelette'],
+      workouts: null,
+      section: 'morning',
+      timestamp: 1
+    } as ScheduleItem;
+  });
+
+  it('should emit section selection events', () => {
+    spyOn(component.selectingSection, 'emit');
+
+    component.onSelect('meals', ['Omelette']);
+
+    expect(component.selectingSection.emit).toHaveBeenCalledWith({
+      type: 'meals',
+      assigned: ['Omelette'],
+      data: component.section
+    });
+  });
+});

--- a/src/app/modules/nav-options/schedule/components/schedule-section/schedule-section.component.ts
+++ b/src/app/modules/nav-options/schedule/components/schedule-section/schedule-section.component.ts
@@ -41,7 +41,7 @@ import { ScheduleItem } from 'src/app/models/schedule-item.interface';
       *ngIf="section.workouts; else addWorkout"
       class="flex-row-container flex-justify-content-start flex-align-items-center padding-10 cursor-pointer background-color-gray-1"
       (click)="onSelect('workouts', section.workouts)">
-      <mat-icon color="primary" aria-hidden="false" aria-label="Meals section">fitness_center</mat-icon>
+      <mat-icon color="primary" aria-hidden="false" aria-label="Workouts section">fitness_center</mat-icon>
       <span class="margin-left-10">{{ section.workouts | join }}</span>
     </div>
     <ng-template #addWorkout>

--- a/src/app/modules/nav-options/schedule/containers/schedule/schedule.component.spec.ts
+++ b/src/app/modules/nav-options/schedule/containers/schedule/schedule.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ScheduleComponent } from './schedule.component';
+import { ScheduleService } from 'src/app/modules/nav-options/shared/services/schedule/schedule.service';
+import { MealsService } from 'src/app/modules/nav-options/shared/services/meals/meals.service';
+import { WorkoutsService } from 'src/app/modules/nav-options/shared/services/workouts/workouts.service';
+import { Store } from 'src/app/store/store';
+import { ScheduleCalendarComponent } from '../../components/schedule-calendar/schedule-calendar.component';
+import { ScheduleAssignComponent } from '../../components/schedule-assign/schedule-assign.component';
+import { ScheduleControlsComponent } from '../../components/schedule-controls/schedule-controls.component';
+import { ScheduleDaysComponent } from '../../components/schedule-days/schedule-days.component';
+import { ScheduleSectionComponent } from '../../components/schedule-section/schedule-section.component';
+import { JoinPipe } from 'src/app/modules/nav-options/shared/pipes/join.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('ScheduleComponent', () => {
+  let component: ScheduleComponent;
+  let scheduleService: jasmine.SpyObj<ScheduleService>;
+
+  beforeEach(async () => {
+    scheduleService = jasmine.createSpyObj('ScheduleService', [
+      'updateDate',
+      'selectSection',
+      'updateItems'
+    ], {
+      schedule$: of({}),
+      selected$: of(null),
+      list$: of([]),
+      items$: of(undefined)
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [
+        ScheduleComponent,
+        ScheduleCalendarComponent,
+        ScheduleAssignComponent,
+        ScheduleControlsComponent,
+        ScheduleDaysComponent,
+        ScheduleSectionComponent,
+        JoinPipe
+      ],
+      providers: [
+        Store,
+        { provide: ScheduleService, useValue: scheduleService },
+        { provide: MealsService, useValue: { meals$: of([]) } },
+        { provide: WorkoutsService, useValue: { workouts$: of([]) } }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(ScheduleComponent).componentInstance;
+    component.ngOnInit();
+  });
+
+  it('should open the assign dialog when a section is selected', () => {
+    const event = {
+      type: 'meals',
+      assigned: [] as string[],
+      data: {
+        meals: null,
+        workouts: null,
+        section: 'morning',
+        timestamp: 1
+      },
+      section: 'morning',
+      day: new Date()
+    };
+
+    component.changeSection(event);
+
+    expect(component.open).toBeTrue();
+    expect(scheduleService.selectSection).toHaveBeenCalledWith(event);
+  });
+
+  it('should close the assign dialog after updating items', () => {
+    component.open = true;
+
+    component.updateItems({ meals: ['Soup'] });
+
+    expect(scheduleService.updateItems).toHaveBeenCalledWith({ meals: ['Soup'] });
+    expect(component.open).toBeFalse();
+  });
+});

--- a/src/app/modules/nav-options/shared/components/list-item/list-item.component.spec.ts
+++ b/src/app/modules/nav-options/shared/components/list-item/list-item.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ListItemComponent } from './list-item.component';
+import { JoinPipe } from '../../pipes/join.pipe';
+import { WorkoutPipe } from '../../pipes/workout.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('ListItemComponent', () => {
+  let fixture: ComponentFixture<ListItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [ListItemComponent, JoinPipe, WorkoutPipe]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListItemComponent);
+  });
+
+  it('should build a meal route when ingredients exist', () => {
+    fixture.componentInstance.item = {
+      name: 'Soup',
+      ingredients: ['water'],
+      $key: 'meal-1'
+    };
+
+    expect(fixture.componentInstance.getRoute(fixture.componentInstance.item)).toEqual(['../meals', 'meal-1']);
+  });
+
+  it('should build a workout route when ingredients are absent', () => {
+    fixture.componentInstance.item = {
+      name: 'Run',
+      type: 'endurance',
+      $key: 'workout-1'
+    };
+
+    expect(fixture.componentInstance.getRoute(fixture.componentInstance.item)).toEqual(['../workouts', 'workout-1']);
+  });
+
+  it('should emit remove events', () => {
+    const item = { name: 'Soup', ingredients: ['water'], $key: 'meal-1' };
+    fixture.componentInstance.item = item;
+    spyOn(fixture.componentInstance.remove, 'emit');
+
+    fixture.componentInstance.removeItem();
+
+    expect(fixture.componentInstance.remove.emit).toHaveBeenCalledWith(item);
+  });
+
+  it('should use workout delete labels for workout items', () => {
+    fixture.componentInstance.item = { name: 'Run', type: 'endurance', $key: 'workout-1' };
+    expect(fixture.componentInstance.deleteLabel).toBe('Delete workout');
+    expect(fixture.componentInstance.cancelDeleteLabel).toBe('Cancel delete workout');
+  });
+});

--- a/src/app/modules/nav-options/shared/components/list-item/list-item.component.ts
+++ b/src/app/modules/nav-options/shared/components/list-item/list-item.component.ts
@@ -29,13 +29,13 @@ import { Component, Input, Output, ChangeDetectionStrategy, EventEmitter } from 
             mat-icon-button
             type="button"
             (click)="removeItem()">
-            <mat-icon color="warn" aria-hidden="false" aria-label="Delete meal">delete</mat-icon>
+            <mat-icon color="warn" aria-hidden="false" [attr.aria-label]="deleteLabel">delete</mat-icon>
           </button>
           <button
             mat-icon-button
             type="button"
             (click)="toggle()">
-            <mat-icon aria-hidden="false" aria-label="Cancel delete meal">cancel</mat-icon>
+            <mat-icon aria-hidden="false" [attr.aria-label]="cancelDeleteLabel">cancel</mat-icon>
           </button>
         </div>
 
@@ -68,6 +68,14 @@ export class ListItemComponent {
 
   removeItem(): void {
     this.remove.emit(this.item);
+  }
+
+  get deleteLabel(): string {
+    return this.item.ingredients ? 'Delete meal' : 'Delete workout';
+  }
+
+  get cancelDeleteLabel(): string {
+    return this.item.ingredients ? 'Cancel delete meal' : 'Cancel delete workout';
   }
 
   getRoute(item: any): any[] {

--- a/src/app/modules/nav-options/shared/pipes/join.pipe.spec.ts
+++ b/src/app/modules/nav-options/shared/pipes/join.pipe.spec.ts
@@ -1,0 +1,13 @@
+import { JoinPipe } from './join.pipe';
+
+describe('JoinPipe', () => {
+  const pipe = new JoinPipe();
+
+  it('should join array values with comma separator', () => {
+    expect(pipe.transform(['eggs', 'bacon'])).toBe('eggs, bacon');
+  });
+
+  it('should return non-array values unchanged', () => {
+    expect(pipe.transform('plain')).toBe('plain');
+  });
+});

--- a/src/app/modules/nav-options/shared/pipes/workout.pipe.spec.ts
+++ b/src/app/modules/nav-options/shared/pipes/workout.pipe.spec.ts
@@ -1,0 +1,28 @@
+import { WorkoutPipe } from './workout.pipe';
+
+describe('WorkoutPipe', () => {
+  const pipe = new WorkoutPipe();
+
+  it('should format strength workouts', () => {
+    const result = pipe.transform({
+      type: 'strength',
+      strength: { weight: 50, reps: 10, sets: 3 },
+      endurance: {}
+    });
+
+    expect(result).toContain('Weight: 50kg');
+    expect(result).toContain('Reps: 10');
+    expect(result).toContain('Sets: 3');
+  });
+
+  it('should format endurance workouts', () => {
+    const result = pipe.transform({
+      type: 'endurance',
+      strength: {},
+      endurance: { distance: 5, duration: 30 }
+    });
+
+    expect(result).toContain('Distance: 5km');
+    expect(result).toContain('Duration: 30mins');
+  });
+});

--- a/src/app/modules/nav-options/shared/services/meals/meals.service.spec.ts
+++ b/src/app/modules/nav-options/shared/services/meals/meals.service.spec.ts
@@ -1,0 +1,115 @@
+import { TestBed } from '@angular/core/testing';
+import { Auth } from '@angular/fire/auth';
+import { Firestore } from '@angular/fire/firestore';
+import { of } from 'rxjs';
+import { MealsService } from './meals.service';
+import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
+import { Store } from 'src/app/store/store';
+import { installFirebaseTestMocks } from 'src/app/testing/firebase-test-harness';
+import { mockAuth, mockFirebaseUser, mockFirestore } from 'src/app/testing/firebase.mock';
+import { Meal } from 'src/app/models/meal.interface';
+
+describe('MealsService', () => {
+  let service: MealsService;
+  let store: Store;
+  let mocks: ReturnType<typeof installFirebaseTestMocks>;
+
+  const meal: Meal = {
+    name: 'Pancakes',
+    ingredients: ['flour', 'milk'],
+    timestamp: 0,
+    $key: 'meal-1',
+    $exists: () => true
+  };
+
+  beforeEach(() => {
+    mocks = installFirebaseTestMocks(mockFirebaseUser);
+    mocks.observeCollectionData.and.returnValue(of([meal]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        MealsService,
+        Store,
+        { provide: Auth, useValue: mockAuth },
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: AuthService, useValue: { user: mockFirebaseUser } }
+      ]
+    });
+
+    service = TestBed.inject(MealsService);
+    store = TestBed.inject(Store);
+  });
+
+  it('should load meals for the authenticated user into the store', (done) => {
+    service.meals$.subscribe(() => {
+      expect(store.value.meals).toEqual([meal]);
+      done();
+    });
+  });
+
+  it('should add meals without AngularFire metadata and with a timestamp', async () => {
+    await service.addMeal({
+      name: 'Toast',
+      ingredients: ['bread'],
+      timestamp: undefined as unknown as number,
+      $key: 'ignored',
+      $exists: () => true
+    });
+
+    expect(mocks.createDocument).toHaveBeenCalled();
+    const payload = mocks.createDocument.calls.mostRecent().args[1] as Record<string, unknown>;
+    expect(payload.$key).toBeUndefined();
+    expect(payload.$exists).toBeUndefined();
+    expect(payload.timestamp).toEqual(jasmine.any(Number));
+  });
+
+  it('should preserve an existing timestamp when updating meals', async () => {
+    await service.updateMeal('meal-1', meal);
+
+    expect(mocks.updateDocument).toHaveBeenCalled();
+    const payload = mocks.updateDocument.calls.mostRecent().args[1] as Record<string, unknown>;
+    expect(payload.name).toBe('Pancakes');
+    expect(payload.$key).toBeUndefined();
+  });
+
+  it('should delete meals by key', async () => {
+    await service.deleteMeal('meal-1');
+
+    expect(mocks.deleteDocument).toHaveBeenCalled();
+  });
+
+  it('should return a blank meal template when no id is provided', (done) => {
+    service.getMeal('').subscribe(value => {
+      expect(value.name).toBe('');
+      expect(value.$exists()).toBeFalse();
+      done();
+    });
+  });
+
+  it('should find a meal from the store by key', (done) => {
+    store.set('meals', [meal]);
+
+    service.getMeal('meal-1').subscribe(value => {
+      expect(value).toEqual(meal);
+      done();
+    });
+  });
+
+  it('should throw when uid is requested without authentication', () => {
+    TestBed.resetTestingModule();
+    installFirebaseTestMocks(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        MealsService,
+        Store,
+        { provide: Auth, useValue: mockAuth },
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: AuthService, useValue: { user: null } }
+      ]
+    });
+
+    const unauthenticatedService = TestBed.inject(MealsService);
+    expect(() => unauthenticatedService.uid).toThrowError('User not authenticated');
+  });
+});

--- a/src/app/modules/nav-options/shared/services/meals/meals.service.ts
+++ b/src/app/modules/nav-options/shared/services/meals/meals.service.ts
@@ -1,15 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
-import {
-  Firestore,
-  collection,
-  collectionData,
-  addDoc,
-  updateDoc,
-  deleteDoc,
-  doc,
-  DocumentReference
-} from '@angular/fire/firestore';
+import { Firestore, DocumentReference } from '@angular/fire/firestore';
 
 // store
 import { Store } from 'src/app/store/store';
@@ -19,11 +10,19 @@ import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.serv
 
 // utils
 import { toFirestoreData } from 'src/app/utils/firestore-document';
+import { observeAuthState } from 'src/app/utils/firebase-auth.utils';
+import {
+  getCollection,
+  observeCollectionData,
+  getDocument,
+  createDocument,
+  updateDocument,
+  deleteDocument
+} from 'src/app/utils/firestore.utils';
 
 // rxjs
 import { Observable, of } from 'rxjs';
 import { tap, map, filter, shareReplay, switchMap } from 'rxjs/operators';
-import { authState } from '@angular/fire/auth';
 
 // interfaces
 import { Meal } from 'src/app/models/meal.interface';
@@ -31,13 +30,13 @@ import { Meal } from 'src/app/models/meal.interface';
 @Injectable()
 export class MealsService {
 
-  meals$: Observable<Meal[]> = authState(this.auth).pipe(
+  meals$: Observable<Meal[]> = observeAuthState(this.auth).pipe(
     filter((user): user is NonNullable<typeof user> => !!user),
     switchMap(user => {
-      const mealsCollection = collection(this.firestore, `users/${user.uid}/meals`);
-      return collectionData(mealsCollection, { idField: '$key' }) as Observable<Meal[]>;
+      const mealsCollection = getCollection(this.firestore, `users/${user.uid}/meals`);
+      return observeCollectionData<Meal>(mealsCollection, { idField: '$key' });
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
     tap((next: Meal[]): void => {
       this.store.set('meals', next);
     })
@@ -59,18 +58,21 @@ export class MealsService {
   }
 
   addMeal(meal: Meal): Promise<DocumentReference> {
-    const mealsCollection = collection(this.firestore, `users/${this.uid}/meals`);
-    return addDoc(mealsCollection, toFirestoreData(meal));
+    const mealsCollection = getCollection(this.firestore, `users/${this.uid}/meals`);
+    return createDocument(mealsCollection, toFirestoreData({
+      ...meal,
+      timestamp: meal.timestamp ?? Date.now()
+    }));
   }
 
   updateMeal(key: string, meal: Meal): Promise<void> {
-    const mealDoc = doc(this.firestore, `users/${this.uid}/meals/${key}`);
-    return updateDoc(mealDoc, toFirestoreData(meal));
+    const mealDoc = getDocument(this.firestore, `users/${this.uid}/meals/${key}`);
+    return updateDocument(mealDoc, toFirestoreData(meal));
   }
 
   deleteMeal(key: string): Promise<void> {
-    const mealDoc = doc(this.firestore, `users/${this.uid}/meals/${key}`);
-    return deleteDoc(mealDoc);
+    const mealDoc = getDocument(this.firestore, `users/${this.uid}/meals/${key}`);
+    return deleteDocument(mealDoc);
   }
 
   getMeal(paramskey: string): Observable<Meal | undefined> {

--- a/src/app/modules/nav-options/shared/services/schedule/schedule.service.spec.ts
+++ b/src/app/modules/nav-options/shared/services/schedule/schedule.service.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed } from '@angular/core/testing';
+import { Auth } from '@angular/fire/auth';
+import { Firestore } from '@angular/fire/firestore';
+import { of } from 'rxjs';
+import { ScheduleService } from './schedule.service';
+import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
+import { Store } from 'src/app/store/store';
+import { installFirebaseTestMocks } from 'src/app/testing/firebase-test-harness';
+import { mockAuth, mockFirebaseUser, mockFirestore } from 'src/app/testing/firebase.mock';
+import { ScheduleItem } from 'src/app/models/schedule-item.interface';
+import { Meal } from 'src/app/models/meal.interface';
+
+describe('ScheduleService', () => {
+  let service: ScheduleService;
+  let store: Store;
+  let mocks: ReturnType<typeof installFirebaseTestMocks>;
+
+  const scheduleItem: ScheduleItem = {
+    meals: ['Omelette'],
+    workouts: null,
+    section: 'morning',
+    timestamp: new Date('2026-07-01T08:00:00').getTime(),
+    $key: 'schedule-1'
+  };
+
+  beforeEach(() => {
+    mocks = installFirebaseTestMocks(mockFirebaseUser);
+    mocks.observeCollectionData.and.returnValue(of([scheduleItem]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ScheduleService,
+        Store,
+        { provide: Auth, useValue: mockAuth },
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: AuthService, useValue: { user: mockFirebaseUser } }
+      ]
+    });
+
+    service = TestBed.inject(ScheduleService);
+    store = TestBed.inject(Store);
+  });
+
+  it('should map schedule documents into a section keyed object', (done) => {
+    service.schedule$.subscribe(() => {
+      expect(store.value.schedule).toEqual({ morning: scheduleItem });
+      done();
+    });
+  });
+
+  it('should keep the first section when duplicate section keys exist', (done) => {
+    const duplicate: ScheduleItem = {
+      ...scheduleItem,
+      meals: ['Toast'],
+      $key: 'schedule-2'
+    };
+
+    mocks.observeCollectionData.and.returnValue(of([scheduleItem, duplicate]));
+
+    TestBed.resetTestingModule();
+    const duplicateMocks = installFirebaseTestMocks(mockFirebaseUser);
+    duplicateMocks.observeCollectionData.and.returnValue(of([scheduleItem, duplicate]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ScheduleService,
+        Store,
+        { provide: Auth, useValue: mockAuth },
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: AuthService, useValue: { user: mockFirebaseUser } }
+      ]
+    });
+
+    const duplicateService = TestBed.inject(ScheduleService);
+    const duplicateStore = TestBed.inject(Store);
+    duplicateService.schedule$.subscribe(() => {
+      expect(duplicateStore.value.schedule.morning.meals).toEqual(['Omelette']);
+      done();
+    });
+  });
+
+  it('should create a new schedule section when assigning without an existing id', (done) => {
+    const day = new Date('2026-07-02T12:00:00');
+
+    service.items$.subscribe(() => {
+      expect(mocks.createDocument).toHaveBeenCalled();
+      const payload = mocks.createDocument.calls.mostRecent().args[1] as ScheduleItem;
+      expect(payload.section).toBe('lunch');
+      expect(payload.meals).toEqual(['Salad']);
+      expect(payload.timestamp).toBe(new Date(day).getTime());
+      done();
+    });
+
+    service.selectSection({
+      type: 'meals',
+      assigned: ['Salad'],
+      data: {} as ScheduleItem,
+      section: 'lunch',
+      day
+    });
+    service.updateItems({ meals: ['Salad'] });
+  });
+
+  it('should update an existing schedule section when an id is present', (done) => {
+    service.items$.subscribe(() => {
+      expect(mocks.updateDocument).toHaveBeenCalled();
+      done();
+    });
+
+    service.selectSection({
+      type: 'meals',
+      assigned: ['Omelette', 'Toast'],
+      data: scheduleItem,
+      section: 'morning',
+      day: new Date(scheduleItem.timestamp)
+    });
+    service.updateItems({ meals: ['Omelette', 'Toast'] });
+  });
+
+  it('should expose meals or workouts for the selected section type', (done) => {
+    const meals: Meal[] = [{
+      name: 'Soup',
+      ingredients: ['water'],
+      timestamp: 1,
+      $key: 'meal-1',
+      $exists: () => true
+    }];
+    store.set('meals', meals);
+
+    service.list$.subscribe(value => {
+      expect(value).toEqual(meals);
+      done();
+    });
+
+    service.selectSection({
+      type: 'meals',
+      assigned: [],
+      data: {} as ScheduleItem,
+      section: 'evening',
+      day: new Date()
+    });
+  });
+});

--- a/src/app/modules/nav-options/shared/services/schedule/schedule.service.ts
+++ b/src/app/modules/nav-options/shared/services/schedule/schedule.service.ts
@@ -1,18 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
-import {
-  Firestore,
-  collection,
-  collectionData,
-  addDoc,
-  updateDoc,
-  doc,
-  query,
-  orderBy,
-  startAt,
-  endAt,
-  DocumentReference
-} from '@angular/fire/firestore';
+import { Firestore, DocumentReference } from '@angular/fire/firestore';
 
 // store
 import { Store } from 'src/app/store/store';
@@ -22,11 +10,22 @@ import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.serv
 
 // utils
 import { toFirestoreData } from 'src/app/utils/firestore-document';
+import { observeAuthState } from 'src/app/utils/firebase-auth.utils';
+import {
+  getCollection,
+  observeCollectionData,
+  getDocument,
+  createDocument,
+  updateDocument,
+  buildQuery,
+  orderByField,
+  startAtValue,
+  endAtValue
+} from 'src/app/utils/firestore.utils';
 
 // rxjs
 import { BehaviorSubject, Subject, Observable, from } from 'rxjs';
 import { tap, map, switchMap, withLatestFrom, filter } from 'rxjs/operators';
-import { authState } from '@angular/fire/auth';
 
 // interfaces
 import { ScheduleList } from 'src/app/models/schedule-list.interface';
@@ -76,7 +75,7 @@ export class ScheduleService {
     tap((next) => this.store.set('list', next))
   );
 
-  schedule$ = authState(this.auth).pipe(
+  schedule$ = observeAuthState(this.auth).pipe(
     filter((user): user is NonNullable<typeof user> => !!user),
     switchMap(user => this.date$.pipe(
       tap((next: Date) => this.store.set('date', next)),
@@ -85,15 +84,15 @@ export class ScheduleService {
         const endAtValue = new Date(day.getFullYear(), day.getMonth(), day.getDate() + 1).getTime() - 1;
         return { startAt: startAtValue, endAt: endAtValue };
       }),
-      switchMap(({ startAt: startAtValue, endAt: endAtValue }) => {
-        const scheduleCollection = collection(this.firestore, `users/${user.uid}/schedule`);
-        const scheduleQuery = query(
+      switchMap(({ startAt: rangeStart, endAt: rangeEnd }) => {
+        const scheduleCollection = getCollection(this.firestore, `users/${user.uid}/schedule`);
+        const scheduleQuery = buildQuery(
           scheduleCollection,
-          orderBy('timestamp'),
-          startAt(startAtValue),
-          endAt(endAtValue)
+          orderByField('timestamp'),
+          startAtValue(rangeStart),
+          endAtValue(rangeEnd)
         );
-        return collectionData(scheduleQuery, { idField: '$key' }) as Observable<ScheduleItem[]>;
+        return observeCollectionData<ScheduleItem>(scheduleQuery, { idField: '$key' });
       }),
       map((data: ScheduleItem[]): ScheduleList => {
         const mapped: ScheduleList = {};
@@ -144,13 +143,13 @@ export class ScheduleService {
   }
 
   private createSection(payload: ScheduleItem): Promise<DocumentReference> {
-    const scheduleCollection = collection(this.firestore, `users/${this.uid}/schedule`);
-    return addDoc(scheduleCollection, toFirestoreData(payload));
+    const scheduleCollection = getCollection(this.firestore, `users/${this.uid}/schedule`);
+    return createDocument(scheduleCollection, toFirestoreData(payload));
   }
 
   private updateSection(key: string, payload: ScheduleItem): Promise<void> {
-    const scheduleDoc = doc(this.firestore, `users/${this.uid}/schedule/${key}`);
-    return updateDoc(scheduleDoc, toFirestoreData(payload));
+    const scheduleDoc = getDocument(this.firestore, `users/${this.uid}/schedule/${key}`);
+    return updateDocument(scheduleDoc, toFirestoreData(payload));
   }
 
 }

--- a/src/app/modules/nav-options/shared/services/workouts/workouts.service.spec.ts
+++ b/src/app/modules/nav-options/shared/services/workouts/workouts.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { Auth } from '@angular/fire/auth';
+import { Firestore } from '@angular/fire/firestore';
+import { of } from 'rxjs';
+import { WorkoutsService } from './workouts.service';
+import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.service';
+import { Store } from 'src/app/store/store';
+import { installFirebaseTestMocks } from 'src/app/testing/firebase-test-harness';
+import { mockAuth, mockFirebaseUser, mockFirestore } from 'src/app/testing/firebase.mock';
+import { Workout } from 'src/app/models/workout.interface';
+
+describe('WorkoutsService', () => {
+  let service: WorkoutsService;
+  let store: Store;
+  let mocks: ReturnType<typeof installFirebaseTestMocks>;
+
+  const workout: Workout = {
+    name: 'Bench press',
+    type: 'strength',
+    strength: { reps: 8, sets: 3, weight: 60 },
+    endurance: {},
+    timestamp: 0,
+    $key: 'workout-1',
+    $exists: () => true
+  };
+
+  beforeEach(() => {
+    mocks = installFirebaseTestMocks(mockFirebaseUser);
+    mocks.observeCollectionData.and.returnValue(of([workout]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        WorkoutsService,
+        Store,
+        { provide: Auth, useValue: mockAuth },
+        { provide: Firestore, useValue: mockFirestore },
+        { provide: AuthService, useValue: { user: mockFirebaseUser } }
+      ]
+    });
+
+    service = TestBed.inject(WorkoutsService);
+    store = TestBed.inject(Store);
+  });
+
+  it('should load workouts into the store', (done) => {
+    service.workouts$.subscribe(() => {
+      expect(store.value.workouts).toEqual([workout]);
+      done();
+    });
+  });
+
+  it('should add workouts without metadata and with a timestamp', async () => {
+    await service.addWorkout({
+      name: 'Run',
+      type: 'endurance',
+      strength: {},
+      endurance: { distance: 5, duration: 30 },
+      timestamp: undefined as unknown as number,
+      $key: 'ignored',
+      $exists: () => true
+    });
+
+    const payload = mocks.createDocument.calls.mostRecent().args[1] as Record<string, unknown>;
+    expect(payload.$key).toBeUndefined();
+    expect(payload.timestamp).toEqual(jasmine.any(Number));
+  });
+
+  it('should return a blank workout template when no id is provided', (done) => {
+    service.getWorkout('').subscribe(value => {
+      expect(value.type).toBe('strength');
+      done();
+    });
+  });
+});

--- a/src/app/modules/nav-options/shared/services/workouts/workouts.service.ts
+++ b/src/app/modules/nav-options/shared/services/workouts/workouts.service.ts
@@ -1,15 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
-import {
-  Firestore,
-  collection,
-  collectionData,
-  addDoc,
-  updateDoc,
-  deleteDoc,
-  doc,
-  DocumentReference
-} from '@angular/fire/firestore';
+import { Firestore, DocumentReference } from '@angular/fire/firestore';
 
 // store
 import { Store } from 'src/app/store/store';
@@ -19,11 +10,19 @@ import { AuthService } from 'src/app/modules/auth/shared/services/auth/auth.serv
 
 // utils
 import { toFirestoreData } from 'src/app/utils/firestore-document';
+import { observeAuthState } from 'src/app/utils/firebase-auth.utils';
+import {
+  getCollection,
+  observeCollectionData,
+  getDocument,
+  createDocument,
+  updateDocument,
+  deleteDocument
+} from 'src/app/utils/firestore.utils';
 
 // rxjs
 import { Observable, of } from 'rxjs';
 import { tap, map, filter, shareReplay, switchMap } from 'rxjs/operators';
-import { authState } from '@angular/fire/auth';
 
 // interfaces
 import { Workout } from 'src/app/models/workout.interface';
@@ -31,13 +30,13 @@ import { Workout } from 'src/app/models/workout.interface';
 @Injectable()
 export class WorkoutsService {
 
-  workouts$: Observable<Workout[]> = authState(this.auth).pipe(
+  workouts$: Observable<Workout[]> = observeAuthState(this.auth).pipe(
     filter((user): user is NonNullable<typeof user> => !!user),
     switchMap(user => {
-      const workoutsCollection = collection(this.firestore, `users/${user.uid}/workouts`);
-      return collectionData(workoutsCollection, { idField: '$key' }) as Observable<Workout[]>;
+      const workoutsCollection = getCollection(this.firestore, `users/${user.uid}/workouts`);
+      return observeCollectionData<Workout>(workoutsCollection, { idField: '$key' });
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
     tap((next: Workout[]): void => {
       this.store.set('workouts', next);
     })
@@ -59,18 +58,21 @@ export class WorkoutsService {
   }
 
   addWorkout(workout: Workout): Promise<DocumentReference> {
-    const workoutsCollection = collection(this.firestore, `users/${this.uid}/workouts`);
-    return addDoc(workoutsCollection, toFirestoreData(workout));
+    const workoutsCollection = getCollection(this.firestore, `users/${this.uid}/workouts`);
+    return createDocument(workoutsCollection, toFirestoreData({
+      ...workout,
+      timestamp: workout.timestamp ?? Date.now()
+    }));
   }
 
   updateWorkout(key: string, workout: Workout): Promise<void> {
-    const workoutDoc = doc(this.firestore, `users/${this.uid}/workouts/${key}`);
-    return updateDoc(workoutDoc, toFirestoreData(workout));
+    const workoutDoc = getDocument(this.firestore, `users/${this.uid}/workouts/${key}`);
+    return updateDocument(workoutDoc, toFirestoreData(workout));
   }
 
   deleteWorkout(key: string): Promise<void> {
-    const workoutDoc = doc(this.firestore, `users/${this.uid}/workouts/${key}`);
-    return deleteDoc(workoutDoc);
+    const workoutDoc = getDocument(this.firestore, `users/${this.uid}/workouts/${key}`);
+    return deleteDocument(workoutDoc);
   }
 
   getWorkout(paramskey: string): Observable<Workout | undefined> {

--- a/src/app/modules/nav-options/workouts/components/workout-form/workout-form.component.spec.ts
+++ b/src/app/modules/nav-options/workouts/components/workout-form/workout-form.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WorkoutFormComponent } from './workout-form.component';
+import { WorkoutTypeComponent } from '../workout-type/workout-type.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('WorkoutFormComponent', () => {
+  let component: WorkoutFormComponent;
+  let fixture: ComponentFixture<WorkoutFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, RouterTestingModule, MaterialModule],
+      declarations: [WorkoutFormComponent, WorkoutTypeComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkoutFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should emit create events for valid strength workouts', () => {
+    spyOn(component.create, 'emit');
+    component.form.setValue({
+      name: 'Bench press',
+      type: 'strength',
+      strength: { reps: 8, sets: 3, weight: 60 },
+      endurance: { distance: 0, duration: 0 }
+    });
+
+    component.createWorkout();
+
+    expect(component.create.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/nav-options/workouts/components/workout-type/workout-type.component.spec.ts
+++ b/src/app/modules/nav-options/workouts/components/workout-type/workout-type.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WorkoutTypeComponent } from './workout-type.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+
+describe('WorkoutTypeComponent', () => {
+  let component: WorkoutTypeComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [WorkoutTypeComponent]
+    }).compileComponents();
+
+    component = TestBed.createComponent(WorkoutTypeComponent).componentInstance;
+    component.registerOnChange(jasmine.createSpy('onChange'));
+    component.registerOnTouched(jasmine.createSpy('onTouch'));
+  });
+
+  it('should write and emit selected workout types', () => {
+    component.writeValue('endurance');
+    component.setSelected('strength');
+
+    expect(component.value).toBe('strength');
+  });
+});

--- a/src/app/modules/nav-options/workouts/containers/workout/workout.component.spec.ts
+++ b/src/app/modules/nav-options/workouts/containers/workout/workout.component.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of, EMPTY } from 'rxjs';
+import { WorkoutComponent } from './workout.component';
+import { WorkoutsService } from 'src/app/modules/nav-options/shared/services/workouts/workouts.service';
+import { WorkoutFormComponent } from '../../components/workout-form/workout-form.component';
+import { WorkoutTypeComponent } from '../../components/workout-type/workout-type.component';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Workout } from 'src/app/models/workout.interface';
+
+describe('WorkoutComponent', () => {
+  let component: WorkoutComponent;
+  let workoutsService: jasmine.SpyObj<WorkoutsService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    workoutsService = jasmine.createSpyObj('WorkoutsService', ['addWorkout', 'updateWorkout', 'deleteWorkout', 'getWorkout'], {
+      workouts$: of([])
+    });
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, ReactiveFormsModule, MaterialModule],
+      declarations: [WorkoutComponent, WorkoutFormComponent, WorkoutTypeComponent],
+      providers: [
+        { provide: WorkoutsService, useValue: workoutsService },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ id: 'workout-1' }),
+            snapshot: { params: { id: 'workout-1' } }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(WorkoutComponent).componentInstance;
+  });
+
+  it('should redirect to workouts when an unknown id is requested', fakeAsync(() => {
+    workoutsService.getWorkout.and.returnValue(of(undefined));
+
+    component.ngOnInit();
+    component.workout$.subscribe();
+    tick();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/workouts']);
+  }));
+
+  it('should create workouts and navigate back to the list', async () => {
+    workoutsService.getWorkout.and.returnValue(EMPTY);
+    workoutsService.addWorkout.and.returnValue(Promise.resolve({ id: 'new-workout' } as never));
+    component.ngOnInit();
+
+    const workout: Workout = {
+      name: 'Run',
+      type: 'endurance',
+      strength: {},
+      endurance: { distance: 5, duration: 30 },
+      timestamp: 1,
+      $key: '',
+      $exists: () => false
+    };
+
+    await component.addWorkout(workout);
+
+    expect(workoutsService.addWorkout).toHaveBeenCalledWith(workout);
+    expect(router.navigate).toHaveBeenCalledWith(['/workouts']);
+  });
+});

--- a/src/app/modules/nav-options/workouts/containers/workouts/workouts.component.spec.ts
+++ b/src/app/modules/nav-options/workouts/containers/workouts/workouts.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { WorkoutsComponent } from './workouts.component';
+import { WorkoutsService } from 'src/app/modules/nav-options/shared/services/workouts/workouts.service';
+import { Store } from 'src/app/store/store';
+import { ListItemComponent } from 'src/app/modules/nav-options/shared/components/list-item/list-item.component';
+import { JoinPipe } from 'src/app/modules/nav-options/shared/pipes/join.pipe';
+import { WorkoutPipe } from 'src/app/modules/nav-options/shared/pipes/workout.pipe';
+import { MaterialModule } from 'src/app/modules/shared/material/material.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Workout } from 'src/app/models/workout.interface';
+
+describe('WorkoutsComponent', () => {
+  let component: WorkoutsComponent;
+  let workoutsService: jasmine.SpyObj<WorkoutsService>;
+
+  beforeEach(async () => {
+    workoutsService = jasmine.createSpyObj('WorkoutsService', ['deleteWorkout'], {
+      workouts$: of([])
+    });
+    workoutsService.deleteWorkout.and.returnValue(Promise.resolve());
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, MaterialModule],
+      declarations: [WorkoutsComponent, ListItemComponent, JoinPipe, WorkoutPipe],
+      providers: [
+        Store,
+        { provide: WorkoutsService, useValue: workoutsService }
+      ]
+    }).compileComponents();
+
+    component = TestBed.createComponent(WorkoutsComponent).componentInstance;
+    component.ngOnInit();
+  });
+
+  it('should delete workouts and handle failures', async () => {
+    const workout: Workout = {
+      name: 'Run',
+      type: 'endurance',
+      strength: {},
+      endurance: { distance: 5, duration: 30 },
+      timestamp: 1,
+      $key: 'workout-1',
+      $exists: () => true
+    };
+
+    await component.removeWorkout(workout);
+
+    expect(workoutsService.deleteWorkout).toHaveBeenCalledWith('workout-1');
+  });
+});

--- a/src/app/modules/nav-options/workouts/containers/workouts/workouts.component.ts
+++ b/src/app/modules/nav-options/workouts/containers/workouts/workouts.component.ts
@@ -86,8 +86,12 @@ export class WorkoutsComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  removeWorkout(event: Workout): void {
-    this.workoutsService.deleteWorkout(event.$key);
+  async removeWorkout(event: Workout): Promise<void> {
+    try {
+      await this.workoutsService.deleteWorkout(event.$key);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
 }

--- a/src/app/modules/not-found/components/not-found.component.spec.ts
+++ b/src/app/modules/not-found/components/not-found.component.spec.ts
@@ -1,0 +1,14 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotFoundComponent } from './not-found.component';
+
+describe('NotFoundComponent', () => {
+  it('should create', async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotFoundComponent]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NotFoundComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('404');
+  });
+});

--- a/src/app/store/store.spec.ts
+++ b/src/app/store/store.spec.ts
@@ -1,0 +1,40 @@
+import { Store } from './store';
+import { Meal } from '../models/meal.interface';
+
+describe('Store', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = new Store();
+  });
+
+  it('should expose default undefined slices', () => {
+    expect(store.value.user).toBeUndefined();
+    expect(store.value.meals).toBeUndefined();
+  });
+
+  it('should set and select state slices', (done) => {
+    const meals: Meal[] = [{
+      name: 'Omelette',
+      ingredients: ['eggs'],
+      timestamp: 1,
+      $key: 'meal-1',
+      $exists: () => true
+    }];
+
+    store.set('meals', meals);
+
+    store.select<Meal[]>('meals').subscribe(value => {
+      expect(value).toEqual(meals);
+      done();
+    });
+  });
+
+  it('should merge updates without dropping other slices', () => {
+    store.set('user', { email: 'a@b.com', uid: '1', authenticated: true });
+    store.set('meals', []);
+
+    expect(store.value.user?.email).toBe('a@b.com');
+    expect(store.value.meals).toEqual([]);
+  });
+});

--- a/src/app/testing/firebase-test-harness.ts
+++ b/src/app/testing/firebase-test-harness.ts
@@ -1,0 +1,70 @@
+import { User } from '@angular/fire/auth';
+import { firebaseAuthApi } from 'src/app/utils/firebase-auth.utils';
+import { firestoreApi } from 'src/app/utils/firestore.utils';
+import { Observable, of } from 'rxjs';
+import { mockFirebaseUser } from './firebase.mock';
+
+export interface FirebaseTestMocks {
+  observeAuthState: jasmine.Spy<(auth: unknown) => Observable<User | null>>;
+  onAuthStateChanged: jasmine.Spy;
+  signInUser: jasmine.Spy;
+  registerUser: jasmine.Spy;
+  signOutUser: jasmine.Spy;
+  getCollection: jasmine.Spy;
+  observeCollectionData: jasmine.Spy;
+  getDocument: jasmine.Spy;
+  createDocument: jasmine.Spy;
+  updateDocument: jasmine.Spy;
+  deleteDocument: jasmine.Spy;
+  buildQuery: jasmine.Spy;
+  orderByField: jasmine.Spy;
+  startAtValue: jasmine.Spy;
+  endAtValue: jasmine.Spy;
+}
+
+function createMocks(user: User | null): FirebaseTestMocks {
+  return {
+    observeAuthState: jasmine.createSpy('observeAuthState').and.returnValue(of(user)),
+    onAuthStateChanged: jasmine.createSpy('onAuthStateChanged').and.callFake((_auth, next) => {
+      (next as (value: User | null) => void)(user);
+      return () => undefined;
+    }),
+    signInUser: jasmine.createSpy('signInUser').and.returnValue(Promise.resolve({ user: mockFirebaseUser })),
+    registerUser: jasmine.createSpy('registerUser').and.returnValue(Promise.resolve({ user: mockFirebaseUser })),
+    signOutUser: jasmine.createSpy('signOutUser').and.returnValue(Promise.resolve()),
+    getCollection: jasmine.createSpy('getCollection').and.callFake((_firestore, path) => ({ path })),
+    observeCollectionData: jasmine.createSpy('observeCollectionData').and.returnValue(of([])),
+    getDocument: jasmine.createSpy('getDocument').and.callFake((_firestore, path: string) => ({ path })),
+    createDocument: jasmine.createSpy('createDocument').and.returnValue(Promise.resolve({ id: 'new-id' })),
+    updateDocument: jasmine.createSpy('updateDocument').and.returnValue(Promise.resolve()),
+    deleteDocument: jasmine.createSpy('deleteDocument').and.returnValue(Promise.resolve()),
+    buildQuery: jasmine.createSpy('buildQuery').and.returnValue({}),
+    orderByField: jasmine.createSpy('orderByField').and.returnValue({}),
+    startAtValue: jasmine.createSpy('startAtValue').and.returnValue({}),
+    endAtValue: jasmine.createSpy('endAtValue').and.returnValue({})
+  };
+}
+
+function assignApiMocks(mocks: FirebaseTestMocks): void {
+  firebaseAuthApi.observeAuthState = mocks.observeAuthState;
+  firebaseAuthApi.onAuthStateChanged = mocks.onAuthStateChanged;
+  firebaseAuthApi.signInUser = mocks.signInUser;
+  firebaseAuthApi.registerUser = mocks.registerUser;
+  firebaseAuthApi.signOutUser = mocks.signOutUser;
+  firestoreApi.getCollection = mocks.getCollection;
+  firestoreApi.observeCollectionData = mocks.observeCollectionData;
+  firestoreApi.getDocument = mocks.getDocument;
+  firestoreApi.createDocument = mocks.createDocument;
+  firestoreApi.updateDocument = mocks.updateDocument;
+  firestoreApi.deleteDocument = mocks.deleteDocument;
+  firestoreApi.buildQuery = mocks.buildQuery;
+  firestoreApi.orderByField = mocks.orderByField;
+  firestoreApi.startAtValue = mocks.startAtValue;
+  firestoreApi.endAtValue = mocks.endAtValue;
+}
+
+export function installFirebaseTestMocks(user: User | null = mockFirebaseUser): FirebaseTestMocks {
+  const mocks = createMocks(user);
+  assignApiMocks(mocks);
+  return mocks;
+}

--- a/src/app/testing/firebase.mock.ts
+++ b/src/app/testing/firebase.mock.ts
@@ -1,0 +1,17 @@
+import { Auth, User } from '@angular/fire/auth';
+import { Firestore } from '@angular/fire/firestore';
+
+export const mockFirebaseUser = {
+  uid: 'test-user-id',
+  email: 'test@example.com'
+} as User;
+
+export const mockAuth = {
+  currentUser: mockFirebaseUser
+} as Auth;
+
+export const mockAuthWithoutUser = {
+  currentUser: null
+} as Auth;
+
+export const mockFirestore = {} as Firestore;

--- a/src/app/utils/firebase-auth.utils.spec.ts
+++ b/src/app/utils/firebase-auth.utils.spec.ts
@@ -1,0 +1,11 @@
+import { firebaseAuthApi } from './firebase-auth.utils';
+
+describe('firebase-auth.utils', () => {
+  it('should expose auth helper functions', () => {
+    expect(typeof firebaseAuthApi.observeAuthState).toBe('function');
+    expect(typeof firebaseAuthApi.onAuthStateChanged).toBe('function');
+    expect(typeof firebaseAuthApi.signInUser).toBe('function');
+    expect(typeof firebaseAuthApi.registerUser).toBe('function');
+    expect(typeof firebaseAuthApi.signOutUser).toBe('function');
+  });
+});

--- a/src/app/utils/firebase-auth.utils.ts
+++ b/src/app/utils/firebase-auth.utils.ts
@@ -1,0 +1,62 @@
+import {
+  Auth,
+  authState,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signOut,
+  User
+} from '@angular/fire/auth';
+import { onAuthStateChanged as firebaseOnAuthStateChanged } from 'firebase/auth';
+import { Observable } from 'rxjs';
+
+export const firebaseAuthApi = {
+  observeAuthState(auth: Auth): Observable<User | null> {
+    return authState(auth);
+  },
+
+  onAuthStateChanged(
+    auth: Auth,
+    next: (user: User | null) => void,
+    error?: (error: Error) => void,
+    completed?: () => void
+  ): () => void {
+    return firebaseOnAuthStateChanged(auth, next, error, completed);
+  },
+
+  signInUser(auth: Auth, email: string, password: string) {
+    return signInWithEmailAndPassword(auth, email, password);
+  },
+
+  registerUser(auth: Auth, email: string, password: string) {
+    return createUserWithEmailAndPassword(auth, email, password);
+  },
+
+  signOutUser(auth: Auth) {
+    return signOut(auth);
+  }
+};
+
+export function observeAuthState(auth: Auth): Observable<User | null> {
+  return firebaseAuthApi.observeAuthState(auth);
+}
+
+export function onAuthStateChanged(
+  auth: Auth,
+  next: (user: User | null) => void,
+  error?: (error: Error) => void,
+  completed?: () => void
+): () => void {
+  return firebaseAuthApi.onAuthStateChanged(auth, next, error, completed);
+}
+
+export function signInUser(auth: Auth, email: string, password: string) {
+  return firebaseAuthApi.signInUser(auth, email, password);
+}
+
+export function registerUser(auth: Auth, email: string, password: string) {
+  return firebaseAuthApi.registerUser(auth, email, password);
+}
+
+export function signOutUser(auth: Auth) {
+  return firebaseAuthApi.signOutUser(auth);
+}

--- a/src/app/utils/firestore-document.spec.ts
+++ b/src/app/utils/firestore-document.spec.ts
@@ -1,0 +1,25 @@
+import { toFirestoreData } from './firestore-document';
+
+describe('toFirestoreData', () => {
+  it('should strip AngularFire metadata fields', () => {
+    const data = {
+      name: 'Breakfast',
+      ingredients: ['eggs'],
+      $key: 'abc123',
+      $exists: () => true
+    };
+
+    expect(toFirestoreData(data)).toEqual({
+      name: 'Breakfast',
+      ingredients: ['eggs']
+    });
+  });
+
+  it('should return a shallow copy without mutating the source', () => {
+    const data = { name: 'Lunch', $key: '1' };
+    const result = toFirestoreData(data);
+
+    expect(result).not.toBe(data);
+    expect(data.$key).toBe('1');
+  });
+});

--- a/src/app/utils/firestore.utils.spec.ts
+++ b/src/app/utils/firestore.utils.spec.ts
@@ -1,0 +1,12 @@
+import { firestoreApi } from './firestore.utils';
+
+describe('firestore.utils', () => {
+  it('should expose firestore helper functions', () => {
+    expect(typeof firestoreApi.getCollection).toBe('function');
+    expect(typeof firestoreApi.observeCollectionData).toBe('function');
+    expect(typeof firestoreApi.createDocument).toBe('function');
+    expect(typeof firestoreApi.updateDocument).toBe('function');
+    expect(typeof firestoreApi.deleteDocument).toBe('function');
+    expect(typeof firestoreApi.buildQuery).toBe('function');
+  });
+});

--- a/src/app/utils/firestore.utils.ts
+++ b/src/app/utils/firestore.utils.ts
@@ -1,0 +1,125 @@
+import {
+  Firestore,
+  collection,
+  collectionData,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  query,
+  orderBy,
+  startAt,
+  endAt,
+  DocumentReference,
+  Query,
+  QueryConstraint,
+  CollectionReference,
+  DocumentData
+} from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+
+export const firestoreApi = {
+  getCollection(firestore: Firestore, path: string): CollectionReference<DocumentData> {
+    return collection(firestore, path);
+  },
+
+  observeCollectionData<T>(
+    reference: CollectionReference<DocumentData> | Query<DocumentData>,
+    options?: { idField?: string }
+  ): Observable<T[]> {
+    return collectionData(reference, options) as Observable<T[]>;
+  },
+
+  getDocument(firestore: Firestore, path: string) {
+    return doc(firestore, path);
+  },
+
+  createDocument(
+    reference: CollectionReference<DocumentData>,
+    data: Record<string, unknown>
+  ): Promise<DocumentReference<DocumentData>> {
+    return addDoc(reference, data);
+  },
+
+  updateDocument(
+    reference: ReturnType<typeof doc>,
+    data: Record<string, unknown>
+  ): Promise<void> {
+    return updateDoc(reference, data);
+  },
+
+  deleteDocument(reference: ReturnType<typeof doc>): Promise<void> {
+    return deleteDoc(reference);
+  },
+
+  buildQuery(
+    reference: CollectionReference<DocumentData>,
+    ...constraints: QueryConstraint[]
+  ) {
+    return query(reference, ...constraints);
+  },
+
+  orderByField(field: string) {
+    return orderBy(field);
+  },
+
+  startAtValue(value: number) {
+    return startAt(value);
+  },
+
+  endAtValue(value: number) {
+    return endAt(value);
+  }
+};
+
+export function getCollection(firestore: Firestore, path: string) {
+  return firestoreApi.getCollection(firestore, path);
+}
+
+export function observeCollectionData<T>(
+  reference: CollectionReference<DocumentData> | Query<DocumentData>,
+  options?: { idField?: string }
+): Observable<T[]> {
+  return firestoreApi.observeCollectionData<T>(reference, options);
+}
+
+export function getDocument(firestore: Firestore, path: string) {
+  return firestoreApi.getDocument(firestore, path);
+}
+
+export function createDocument(
+  reference: CollectionReference<DocumentData>,
+  data: Record<string, unknown>
+) {
+  return firestoreApi.createDocument(reference, data);
+}
+
+export function updateDocument(
+  reference: ReturnType<typeof doc>,
+  data: Record<string, unknown>
+) {
+  return firestoreApi.updateDocument(reference, data);
+}
+
+export function deleteDocument(reference: ReturnType<typeof doc>) {
+  return firestoreApi.deleteDocument(reference);
+}
+
+export function buildQuery(
+  reference: CollectionReference<DocumentData>,
+  ...constraints: QueryConstraint[]
+) {
+  return firestoreApi.buildQuery(reference, ...constraints);
+}
+
+export function orderByField(field: string) {
+  return firestoreApi.orderByField(field);
+}
+
+export function startAtValue(value: number) {
+  return firestoreApi.startAtValue(value);
+}
+
+export function endAtValue(value: number) {
+  return firestoreApi.endAtValue(value);
+}

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -22,7 +22,7 @@
     font-weight: 900;
     font-style: normal;
     src: url("/assets/fonts/the_message-bold-webfont.eot");
-    src: url("/assets/fonts/the_message-demibold-webfont.eot?#iefix") format("eot"), url("/assets/fonts/the_message-bold-webfont.woff") format("woff"), url("/assets/fonts/the_message-bold-webfont.ttf") format("truetype"), url("/assets/fonts/the_message-bold-webfont.svg#the_messagebold") format("svg");
+    src: url("/assets/fonts/the_message-bold-webfont.eot?#iefix") format("eot"), url("/assets/fonts/the_message-bold-webfont.woff") format("woff"), url("/assets/fonts/the_message-bold-webfont.ttf") format("truetype"), url("/assets/fonts/the_message-bold-webfont.svg#the_messagebold") format("svg");
 }
 
 @font-face {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **73 unit tests** covering services, guards, pipes, utils, and components across the app (up from 1).
- Introduces `firebase-auth.utils` and `store.utils` wrappers so Firebase calls can be mocked reliably in Karma/Jasmine.
- Fixes several bugs discovered while writing tests.

## Test coverage

| Area | Spec files |
|------|------------|
| Utils | `firestore-document`, `firebase-auth.utils`, `firestore.utils` |
| Store / pipes | `store`, `join`, `workout` |
| Auth | `AuthGuard`, `AuthService`, `AuthForm`, `Login`, `Register` |
| Meals / workouts | services, list/detail containers, forms, list item |
| Schedule | service, calendar, controls, days, section, assign, container |
| App shell | `AppComponent`, `AppHeader`, `AppNav`, `NotFound` |

## Bug fixes

- **Timestamp on create:** meals/workouts now get `Date.now()` when `timestamp` is missing on add.
- **Delete handling:** meal/workout list deletes are awaited with error logging instead of fire-and-forget promises.
- **Memory:** `shareReplay({ refCount: true })` on meals/workouts streams.
- **Fonts:** corrected bold `@font-face` eot fallback in `fonts.scss`.
- **A11y:** fixed workouts nav/section aria labels and list-item delete labels for workouts.

## Verification

```
npm run verify   # lint + build + 73/73 tests passing
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f26b4-05ac-7765-9903-828bf6a46f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f26b4-05ac-7765-9903-828bf6a46f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

